### PR TITLE
Update mountpoint_controller.go to use spec.Password as password

### DIFF
--- a/controllers/mountpoint_controller.go
+++ b/controllers/mountpoint_controller.go
@@ -165,7 +165,7 @@ func (r *MountPointReconciler) manageOperatorLogic(obj *netconfv1.MountPoint, lo
 
 	sshConfig := &ssh.ClientConfig{
 		User:            obj.Spec.Username,
-		Auth:            []ssh.AuthMethod{ssh.Password(obj.Spec.Username)},
+		Auth:            []ssh.AuthMethod{ssh.Password(obj.Spec.Password)},
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 	}
 


### PR DESCRIPTION
Fixed bug in the mountpoint controller that set the password as the username.